### PR TITLE
fixing case where 0 octets throw exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
         "branch-alias": {
             "dev-master": "2.2.5-dev"
         }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.6"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="dTRIP Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <blacklist>
+            <directory suffix=".php">./tests</directory>
+            <directory suffix=".php">./vendor</directory>
+        </blacklist>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/dTR/Networking/dTRIP.php
+++ b/src/dTR/Networking/dTRIP.php
@@ -13,7 +13,7 @@ namespace dTR\Networking;
 
 /**
  * dTR-IP - Class
- * 
+ *
  * @author Mike Mackintosh
  *
  * @returns json_encoded objects
@@ -24,62 +24,62 @@ class dTRIP{
 	public $ip;
 	public $cidr;
 	public $version;
-			
+
 	/**
 	 * __construct()
-	 * 
+	 *
 	 * @param string $ip
 	 * @param int $cidr
 	 * @throws \Exception on invalid arguments
 	 */
 	function __construct($ip, $cidr = NULL){
-		
+
 		$this->ip = $ip;
 		$this->cidr = $cidr;
-		
+
 		if( is_null($this->cidr) AND ($cidrpos = strpos($this->ip, "/")) !== false){
 
 			$this->ip = substr($ip, 0, $cidrpos);
 			$this->cidr = substr($ip, $cidrpos+1);
-		
+
 		}
 
 		/** **/
 		$this->ip_long = dtr_pton( $this->ip );
-		
+
 		/** Detect if it is a valid IPv4 Address **/
 		if(filter_var($this->ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
-			
+
 			$this->version = 4;
 			$this->netmask = $this->netmask();
-				
+
 			return true;
-			
-		}
-		
-		/** Detect if it is a valid IPv6 Address **/
-		elseif(filter_var($this->ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
-			
-			$this->version = 6;
-			$this->netmask = $this->netmask();
-				
-			return true;
-			
+
 		}
 
-		
+		/** Detect if it is a valid IPv6 Address **/
+		elseif(filter_var($this->ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+
+			$this->version = 6;
+			$this->netmask = $this->netmask();
+
+			return true;
+
+		}
+
+
 		/** If not, throw error **/
 		throw new \Exception("Invalid IP/CIDR combination supplied");
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Magic Functions
 	 * @return string
 	 */
 	public function __toString(){
-		
+
 		return json_encode(
 			array(
 				"ip" => $this->ip,
@@ -87,13 +87,13 @@ class dTRIP{
 				"netmask" => dtr_ntop($this->netmask),
 				"network" => $this->network(),
 				"broadcast" => $this->broadcast(),
-			)		
+			)
 		);
-		
+
 	}
-	
+
 	public function __call($method, $args){
-		
+
 		/** Is there a generic function? **/
 		if(method_exists($this, $method)){
 			return $this->$method($args);
@@ -102,11 +102,11 @@ class dTRIP{
 		elseif(method_exists($this, $method."_v".$this->version)){
 			return $this->{$method."_v".$this->version}($args);
 		}
-		
+
 		throw new \Exception("Invalid access method");
-		
+
 		return false;
-	
+
 	}
 
 	/**
@@ -114,10 +114,10 @@ class dTRIP{
 	 * @return string
 	 */
 	public function network(){
-		
+
 		$network = $this->ip_long & $this->netmask;
         return $this->network = dtr_ntop($network);
-	
+
 	}
 
 	/**
@@ -129,65 +129,65 @@ class dTRIP{
 		$netmask = ((1<<32) -1) << (32-$this->cidr);
 		return dtr_pton(long2ip($netmask));
 	}
-	
+
 	function netmask_v6()
 	{
 		$hosts = (128 - $this->cidr);
 		$networks = 128 - $hosts;
-		
+
 		$_m = str_repeat("1", $networks).str_repeat("0", $hosts);
-		
+
 		$_hexMask = null;
 		foreach( str_split( $_m, 4) as $segment){
 		  $_hexMask .= base_convert( $segment, 2, 16);
 		}
-		
+
 		$mask = substr(preg_replace("/([A-f0-9]{4})/", "$1:", $_hexMask), 0, -1);
-		
+
 		return dtr_pton($mask);
 	}
-	
+
 	/**
 	 * Netmask Functions
 	 * @return string
-	 */	
+	 */
 	function broadcast()
 	{
 		$broadcast = $this->ip_long | ~($this->netmask);
 		$this->broadcast = dtr_ntop($broadcast);
 		return $this->broadcast;
 	}
-	
+
 	/**
 	 * Interactive Functions
 	 * @return string
 	 */
-	
+
 	// Return IP
 	public function getIP(){
 		return $this->ip;
 	}
-	
+
 	// Return CIDR
 	public function getCIDR(){
 		return $this->cidr;
 	}
-	
+
 	// Return Netmask in printable format
 	public function getNetmask(){
 		return dtr_ntop($this->netmask);
 	}
-	
+
 	// Return network
 	public function getNetwork(){
 		return $this->network();
 	}
-	
+
 	// Return Broadcast
 	public function getBroadcast(){
 		return $this->broadcast();
 	}
-	
+
 }
 
 /**
@@ -200,12 +200,12 @@ class dTRIP{
  * @return string $bin
  */
 function dtr_pton( $ip ){
-		
+
     if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
-        return current( unpack( "A4", inet_pton( $ip ) ) );
+        return current( unpack( "a4", inet_pton( $ip ) ) );
     }
     elseif(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
-        return current( unpack( "A16", inet_pton( $ip ) ) );
+        return current( unpack( "a16", inet_pton( $ip ) ) );
     }
 
     throw new \Exception("Please supply a valid IPv4 or IPv6 address");
@@ -225,7 +225,7 @@ function dtr_pton( $ip ){
  */
 function dtr_ntop( $str ){
     if( strlen( $str ) == 16 OR strlen( $str ) == 4 ){
-        return inet_ntop( pack( "A".strlen( $str ) , $str ) );
+        return inet_ntop( pack( "a".strlen( $str ) , $str ) );
     }
 
     throw new \Exception( "Please provide a 4 or 16 byte string" );

--- a/tests/dTR/Networking/dTRIPTest.php
+++ b/tests/dTR/Networking/dTRIPTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace dTR\Networking;
+
+class dTRIPTest extends \PHPUnit_Framework_TestCase
+{
+    public function dataProviderIpRanges()
+    {
+        return array(
+            array('10.22.99.199/28', '10.22.99.192', '10.22.99.207'),
+            array('fe80:dead:15:a:bad:1dea:11:2234/93', 'fe80:dead:15:a:bad:1de8::', 'fe80:dead:15:a:bad:1def:ffff:ffff'),
+            array('8.37.230.0/24', '8.37.230.0', '8.37.230.255'),
+            array('192.168.100.14/24', '192.168.100.0', '192.168.100.255'),
+            array('192.168.100.0/22', '192.168.100.0', '192.168.103.255'),
+            array('2001:db8::/48', '2001:db8::', '2001:db8::ffff:ffff:ffff:ffff:ffff'),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderIpRanges
+     */
+    public function testIpRanges($cidr, $network, $broadcast)
+    {
+        $net = new dTRIP($cidr);
+
+        $this->assertEquals($network, $net->getNetwork(), 'Wrong network');
+        $this->assertEquals($broadcast, $net->getBroadcast(), 'Wrong broadcast');
+    }
+}


### PR DESCRIPTION
This was mentioned in the comments of this article:

https://www.mikemackintosh.com/5-tips-for-working-with-ipv6-in-php/

Specifically:

>In those functions, the 'A' causes '0' octets to become an ASCII space
(32 or \x20), rather than the NUL that an 'a' produces.

I setup a couple of tests that exhibited this behavior, which would
throw this exception when the IP had a “0” for an octet:

>Exception: Please provide a 4 or 16 byte string
>
>/Users/jasonklehr/Sites/dTR-IP/src/dTR/Networking/dTRIP.php:231

Changing the “A” in the pack/unpack calls to “a” seems to fix this
behavior.

I’ve added a few other ranges to the test data provider for good
measure.